### PR TITLE
Fix: product soft deletes system

### DIFF
--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -48,7 +48,7 @@ class AdminDashboardController extends Controller
         if ($tab === 'default') {
             // $query->where('status', 'invalid');
         } elseif ($tab === 'dihapus') {
-            $query->onlyTrashed();
+            $query->onlyTrashed()->where('deleted_by_admin', true);
         }
 
         $products = $query
@@ -86,7 +86,7 @@ class AdminDashboardController extends Controller
 
     public function sellerVerification()
     {
-        $sellers = Seller::orderByRaw('admin_verified_at IS NOT NULL') 
+        $sellers = Seller::orderByRaw('admin_verified_at IS NOT NULL')
             ->orderBy('admin_verified_at', 'desc')
             ->paginate(4);
 

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -149,10 +149,6 @@ class ProductController extends Controller
     {
         if (!$this->canDoAction($product)) abort(403);
 
-        foreach ($product->images as $image) {
-            Storage::disk('public')->delete($image->filepath);
-            $image->delete();
-        }
         $product->delete();
 
         return redirect()->route('seller.products.index')->with('success', 'Product deleted successfully!');

--- a/app/Http/Controllers/ProductWarningController.php
+++ b/app/Http/Controllers/ProductWarningController.php
@@ -26,10 +26,6 @@ class ProductWarningController extends Controller
 
     public function destroy(Product $product)
     {
-        foreach ($product->images as $image) {
-            Storage::disk('public')->delete($image->filepath);
-            $image->delete();
-        }
         $seller = $product->seller;
         $product->delete();
 

--- a/app/Http/Controllers/ProductWarningController.php
+++ b/app/Http/Controllers/ProductWarningController.php
@@ -24,9 +24,13 @@ class ProductWarningController extends Controller
         return view("admin.dashboard.monitoring-create", compact('product', 'productImages'));
     }
 
-    public function destroy(Product $product)
+    public function destroy(Product $product) // remove product by admin 
     {
         $seller = $product->seller;
+
+        $product->deleted_by_admin = true;
+        $product->save();
+        
         $product->delete();
 
         $seller->notify(new ProductWarningProductDeletedNotification("$product->name deleted by Admin, ignored warning too long."));

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -52,9 +52,5 @@ class Product extends Model
                 $model->id = Str::ulid()->toBase32();
             }
         });
-
-        static::deleting(function ($model) {
-            Storage::disk('public')->delete($model->image_cover);
-        });
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -21,7 +21,8 @@ class Product extends Model
         'price',
         'description',
         'image_cover',
-        'seller_id'
+        'seller_id',
+        'deleted_by_admin'
     ];
 
     public function images(): HasMany

--- a/database/migrations/2025_05_13_130226_add_deleted_by_admin_to_products_table.php
+++ b/database/migrations/2025_05_13_130226_add_deleted_by_admin_to_products_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->boolean('deleted_by_admin')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('deleted_by_admin');
+        });
+    }
+};


### PR DESCRIPTION
- Ensure that deleting a product does not remove associated image files from the storage directory. This prevents unintended loss of data.
- Modify the admin dashboard logic to display only products that were deleted by an admin (deleted_by_admin = true). Soft-deleted products that were removed by other actors (e.g., sellers) should be excluded from the admin view

